### PR TITLE
Added missing equals for TypeInfo_Const

### DIFF
--- a/arsd-webassembly/object.d
+++ b/arsd-webassembly/object.d
@@ -542,6 +542,8 @@ class TypeInfo_Const : TypeInfo {
 	TypeInfo base;
 	override size_t size() const { return base.size; }
 	override const(TypeInfo) next() const { return base; }
+	
+	override bool equals(void* p1, void* p2) { return base.equals(p1, p2); 	}
 }
 /+
 class TypeInfo_Immutable : TypeInfo {


### PR DESCRIPTION
This test now passes:

```D
struct VertexB
{
    float[2] pos;
}

struct Hold
{
    VertexB v;
}

void main()
{
    Hold[1] h_a;
    Hold[1] h_b;

    assert(h_a[0].v.pos != h_b[0].v.pos);
    assert(h_a[0].v != h_b[0].v);
    assert(h_a[0] != h_b[0]);
    assert(h_a != h_b);

    h_a[0].v.pos = [0, 0];
    h_b[0].v.pos = [0, 0];

    assert(h_a[0].v.pos == h_b[0].v.pos);
    assert(h_a[0].v == h_b[0].v);
    assert(h_a[0] == h_b[0]);
    assert(h_a == h_b);
}
```


How i found it?

I added a print line in the TypeInfo base equals, that gave me the hint that one type had a missing one! then looked one by one!