### PR TITLE
TypeInfo_Const 'next' function should return base's next, and not just 'base'

### DIFF
--- a/arsd-webassembly/object.d
+++ b/arsd-webassembly/object.d
@@ -544,7 +544,7 @@ class TypeInfo_Const : TypeInfo {
 	size_t getHash(in void*) nothrow { return 0; }
 	TypeInfo base;
 	override size_t size() const { return base.size; }
-	override const(TypeInfo) next() const { return base; }
+	override const(TypeInfo) next() const { return base.next; }
 	
 	override bool equals(void* p1, void* p2) { return base.equals(p1, p2); 	}
 }


### PR DESCRIPTION
Following what's in druntime:

https://github.com/dlang/druntime/blob/cb9f7c519cd5c8bf8833b6dac4e95ed92c51876d/src/object.d#L1992