### PR TITLE
Initializers + cast + string switch

### DIFF
--- a/arsd-webassembly/object.d
+++ b/arsd-webassembly/object.d
@@ -615,8 +615,6 @@ extern(C) void[] _d_newarrayiT(const TypeInfo ti, size_t length)
 		case T.sizeof:
 			if (tinext.talign % T.alignof == 0)
 			{
-				import std.stdio;
-				writeln("Default", size, length, T.sizeof);
 				(cast(T*)result.ptr)[0 .. size * length / T.sizeof] = *cast(T*)init.ptr;
 				return result;
 			}

--- a/arsd-webassembly/object.d
+++ b/arsd-webassembly/object.d
@@ -304,7 +304,7 @@ extern(C) void *memcpy(void* dest, const(void)* src, size_t n)
 	return dest;
 }
 
-int memcmp(const(void)* s1, const(void*) s2, size_t n) {
+int memcmp(const(void)* s1, const(void*) s2, size_t n) pure @nogc nothrow @trusted {
 	auto b = cast(ubyte*) s1;
 	auto b2 = cast(ubyte*) s2;
 
@@ -329,7 +329,10 @@ extern(C) void _d_assert_msg(string msg, string file, uint line)
 	arsd.webassembly.abort();
 }
 
-void __switch_error(string file, size_t line) @nogc nothrow pure @safe {}
+void __switch_error(string file, size_t line)
+{
+	_d_assert_msg("final switch error",file, line);
+}
 
 bool __equals(T1, T2)(scope const T1[] lhs, scope const T2[] rhs) {
 	if (lhs.length != rhs.length) {
@@ -403,6 +406,243 @@ int _d_isbaseof2(scope TypeInfo_Class oc, scope const TypeInfo_Class c, scope re
 
     return false;
 }
+
+int __cmp(T)(scope const T[] lhs, scope const T[] rhs) @trusted pure @nogc nothrow
+    if (__traits(isScalar, T))
+{
+    // Compute U as the implementation type for T
+    static if (is(T == ubyte) || is(T == void) || is(T == bool))
+        alias U = char;
+    else static if (is(T == wchar))
+        alias U = ushort;
+    else static if (is(T == dchar))
+        alias U = uint;
+    else static if (is(T == ifloat))
+        alias U = float;
+    else static if (is(T == idouble))
+        alias U = double;
+    else static if (is(T == ireal))
+        alias U = real;
+    else
+        alias U = T;
+
+    static if (is(U == char))
+    {
+        int dstrcmp(scope const char[] s1, scope const char[] s2 ) @trusted pure @nogc nothrow
+		{
+			immutable len = s1.length <= s2.length ? s1.length : s2.length;
+			if (__ctfe)
+			{
+				foreach (const u; 0 .. len)
+				{
+					if (s1[u] != s2[u])
+						return s1[u] > s2[u] ? 1 : -1;
+				}
+			}
+			else
+			{
+				const ret = memcmp( s1.ptr, s2.ptr, len );
+				if ( ret )
+					return ret;
+			}
+			return (s1.length > s2.length) - (s1.length < s2.length);
+		}
+        return dstrcmp(cast(char[]) lhs, cast(char[]) rhs);
+    }
+    else static if (!is(U == T))
+    {
+        // Reuse another implementation
+        return __cmp(cast(U[]) lhs, cast(U[]) rhs);
+    }
+    else
+    {
+        version (BigEndian)
+        static if (__traits(isUnsigned, T) ? !is(T == __vector) : is(T : P*, P))
+        {
+            if (!__ctfe)
+            {
+                import core.stdc.string : memcmp;
+                int c = memcmp(lhs.ptr, rhs.ptr, (lhs.length <= rhs.length ? lhs.length : rhs.length) * T.sizeof);
+                if (c)
+                    return c;
+                static if (size_t.sizeof <= uint.sizeof && T.sizeof >= 2)
+                    return cast(int) lhs.length - cast(int) rhs.length;
+                else
+                    return int(lhs.length > rhs.length) - int(lhs.length < rhs.length);
+            }
+        }
+
+        immutable len = lhs.length <= rhs.length ? lhs.length : rhs.length;
+        foreach (const u; 0 .. len)
+        {
+            auto a = lhs.ptr[u], b = rhs.ptr[u];
+            static if (is(T : creal))
+            {
+                // Use rt.cmath2._Ccmp instead ?
+                // Also: if NaN is present, numbers will appear equal.
+                auto r = (a.re > b.re) - (a.re < b.re);
+                if (!r) r = (a.im > b.im) - (a.im < b.im);
+            }
+            else
+            {
+                // This pattern for three-way comparison is better than conditional operators
+                // See e.g. https://godbolt.org/z/3j4vh1
+                const r = (a > b) - (a < b);
+            }
+            if (r) return r;
+        }
+        return (lhs.length > rhs.length) - (lhs.length < rhs.length);
+    }
+}
+
+// This function is called by the compiler when dealing with array
+// comparisons in the semantic analysis phase of CmpExp. The ordering
+// comparison is lowered to a call to this template.
+int __cmp(T1, T2)(T1[] s1, T2[] s2)
+if (!__traits(isScalar, T1) && !__traits(isScalar, T2))
+{
+    import core.internal.traits : Unqual;
+    alias U1 = Unqual!T1;
+    alias U2 = Unqual!T2;
+
+    static if (is(U1 == void) && is(U2 == void))
+        static @trusted ref inout(ubyte) at(inout(void)[] r, size_t i) { return (cast(inout(ubyte)*) r.ptr)[i]; }
+    else
+        static @trusted ref R at(R)(R[] r, size_t i) { return r.ptr[i]; }
+
+    // All unsigned byte-wide types = > dstrcmp
+    immutable len = s1.length <= s2.length ? s1.length : s2.length;
+
+    foreach (const u; 0 .. len)
+    {
+        static if (__traits(compiles, __cmp(at(s1, u), at(s2, u))))
+        {
+            auto c = __cmp(at(s1, u), at(s2, u));
+            if (c != 0)
+                return c;
+        }
+        else static if (__traits(compiles, at(s1, u).opCmp(at(s2, u))))
+        {
+            auto c = at(s1, u).opCmp(at(s2, u));
+            if (c != 0)
+                return c;
+        }
+        else static if (__traits(compiles, at(s1, u) < at(s2, u)))
+        {
+            if (int result = (at(s1, u) > at(s2, u)) - (at(s1, u) < at(s2, u)))
+                return result;
+        }
+        else
+        {
+            // TODO: fix this legacy bad behavior, see
+            // https://issues.dlang.org/show_bug.cgi?id=17244
+            static assert(is(U1 == U2), "Internal error.");
+            import core.stdc.string : memcmp;
+            auto c = (() @trusted => memcmp(&at(s1, u), &at(s2, u), U1.sizeof))();
+            if (c != 0)
+                return c;
+        }
+    }
+    return (s1.length > s2.length) - (s1.length < s2.length);
+}
+
+
+
+/**
+Support for switch statements switching on strings.
+Params:
+    caseLabels = sorted array of strings generated by compiler. Note the
+        strings are sorted by length first, and then lexicographically.
+    condition = string to look up in table
+Returns:
+    index of match in caseLabels, a negative integer if not found
+*/
+int __switch(T, caseLabels...)(/*in*/ const scope T[] condition) pure nothrow @safe @nogc
+{
+    // This closes recursion for other cases.
+    static if (caseLabels.length == 0)
+    {
+        return int.min;
+    }
+    else static if (caseLabels.length == 1)
+    {
+        return __cmp(condition, caseLabels[0]) == 0 ? 0 : int.min;
+    }
+    // To be adjusted after measurements
+    // Compile-time inlined binary search.
+    else static if (caseLabels.length < 7)
+    {
+        int r = void;
+        enum mid = cast(int)caseLabels.length / 2;
+        if (condition.length == caseLabels[mid].length)
+        {
+            r = __cmp(condition, caseLabels[mid]);
+            if (r == 0) return mid;
+        }
+        else
+        {
+            // Equivalent to (but faster than) condition.length > caseLabels[$ / 2].length ? 1 : -1
+            r = ((condition.length > caseLabels[mid].length) << 1) - 1;
+        }
+
+        if (r < 0)
+        {
+            // Search the left side
+            return __switch!(T, caseLabels[0 .. mid])(condition);
+        }
+        else
+        {
+            // Search the right side
+            return __switch!(T, caseLabels[mid + 1 .. $])(condition) + mid + 1;
+        }
+    }
+    else
+    {
+        // Need immutable array to be accessible in pure code, but case labels are
+        // currently coerced to the switch condition type (e.g. const(char)[]).
+        pure @trusted nothrow @nogc asImmutable(scope const(T[])[] items)
+        {
+            assert(__ctfe); // only @safe for CTFE
+            immutable T[][caseLabels.length] result = cast(immutable)(items[]);
+            return result;
+        }
+        static immutable T[][caseLabels.length] cases = asImmutable([caseLabels]);
+
+        // Run-time binary search in a static array of labels.
+        return __switchSearch!T(cases[], condition);
+    }
+}
+
+// binary search in sorted string cases, also see `__switch`.
+private int __switchSearch(T)(/*in*/ const scope T[][] cases, /*in*/ const scope T[] condition) pure nothrow @safe @nogc
+{
+    size_t low = 0;
+    size_t high = cases.length;
+
+    do
+    {
+        auto mid = (low + high) / 2;
+        int r = void;
+        if (condition.length == cases[mid].length)
+        {
+            r = __cmp(condition, cases[mid]);
+            if (r == 0) return cast(int) mid;
+        }
+        else
+        {
+            // Generates better code than "expr ? 1 : -1" on dmd and gdc, same with ldc
+            r = ((condition.length > cases[mid].length) << 1) - 1;
+        }
+
+        if (r > 0) low = mid + 1;
+        else high = mid;
+    }
+    while (low < high);
+
+    // Not found
+    return -1;
+}
+
 
 // for floats
 extern(C) double fmod(double f, double w) {

--- a/test_runtime.d
+++ b/test_runtime.d
@@ -62,5 +62,19 @@ void main()
 	Tester[] t = new Tester[10];
 	assert(t[0] == Tester.init);
 	assert(t.length == 10);
+
+	switch("hello")
+	{
+		case "test":
+			writeln("broken");
+			break;
+		case "hello":
+			writeln("Working switch string");
+			break;
+		default: writeln("What happenned here?");
+	}
+	string strTest = "test"[0..$];
+	assert(strTest == "test");
+
 }
 

--- a/test_runtime.d
+++ b/test_runtime.d
@@ -1,0 +1,66 @@
+// ldc2 -i=. -i=std --d-version=CarelessAllocation -Iarsd-webassembly/ -L-allow-undefined -ofserver/omg.wasm -mtriple=wasm32-unknown-unknown-wasm runtime_test arsd-webassembly/object.d
+
+import arsd.webassembly;
+import std.stdio;
+
+class A {
+	int _b = 200;
+	int a() { return 123; }
+}
+
+interface C {
+	void test();
+}
+interface D {
+	void check();
+}
+
+class B : A, C 
+{
+	int val;
+	override int a() { return 455 + val; }
+
+	void test()
+	{
+		rawlog(a());
+		int[] a;
+		a~= 1;
+	}
+}
+
+void rawlog(Args...)(Args a, string file = __FILE__, size_t line = __LINE__)
+{
+	writeln(a, " at "~ file~ ":", line);
+}
+
+
+struct Tester
+{
+	int b = 50;
+	string a = "hello";
+}
+void main() 
+{
+	float[] f = new float[4];
+	assert(f[0] is float.init);
+	f~= 5.5; //Append
+	f~= [3, 4];
+	int[] inlineConcatTest = [1, 2] ~ [3, 4];
+
+	auto dg = delegate()
+	{
+		writeln(inlineConcatTest[0], f[1]);
+	};
+	dg();
+	B b = new B;
+	b.val = 5;
+	A a = b;
+	a.a();
+	C c = b;
+	c.test();
+	assert(cast(D)c is null);
+	Tester[] t = new Tester[10];
+	assert(t[0] == Tester.init);
+	assert(t.length == 10);
+}
+


### PR DESCRIPTION
Array initializer fixed:
float[] f = new float[2]; assert(float[0] is float.init) Struct Array initializer fixed.
Interface cast
assert message now showing the message

Added missing properties for delegate and const.
Added version for CarelessAllocation which will enable every allocation that should require a GC. inline_concat version.